### PR TITLE
Fix RL rotation condition in delete

### DIFF
--- a/red_black_tree.cpp
+++ b/red_black_tree.cpp
@@ -509,7 +509,7 @@ rb_tree::node *rb_tree::delete_node(node *now, int data)
                     {
                         del_p = RR_rotation(del_p, child);
                     }
-                    else if (child->rchild && child->rchild->color == RED) // RL rotaton
+                    else if (child->lchild && child->lchild->color == RED) // RL rotaton
                     {
                         del_p = RL_rotation(del_p, child);
                     }


### PR DESCRIPTION
## Summary
- correct RL rotation condition when fixing tree after deletion

## Testing
- `g++ -std=c++11 red_black_tree.cpp && ./a.out > output.txt && tail -n 20 output.txt`


------
https://chatgpt.com/codex/tasks/task_e_6842560ec1088320a1425685bbfee9f4